### PR TITLE
Implement CRUD for Tag

### DIFF
--- a/app/blueprints/tag_blueprint.rb
+++ b/app/blueprints/tag_blueprint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TagBlueprint < Blueprinter::Base
   identifier :id
 

--- a/app/blueprints/tag_blueprint.rb
+++ b/app/blueprints/tag_blueprint.rb
@@ -1,0 +1,5 @@
+class TagBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :name
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound do |e|
+    render json: { error: "Resource not found", details: e.message }, status: :not_found
+  end
+
+  rescue_from ActionController::ParameterMissing do |e|
+    render json: { error: "Missing parameters", details: e.message }, status: :bad_request
+  end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -3,21 +3,28 @@ class TagsController < ApplicationController
 
   def index
     @tags = Tag.all
+    render json: TagBlueprint.render(@tags)
   end
 
   def show
+    render json: TagBlueprint.render(@tag)
   end
 
   def create
-    tag = Tag.create(tag_params)
-
-    redirect_to tags_path
+    tag = Tag.new(tag_params)
+    if tag.save
+      render json: TagBlueprint.render(tag), status: :created
+    else
+      render json: { errors: tag.errors.full_messages }, status: :unprocessable_entity
+    end
   end
 
   def update
-    @tag.update(tag_params)
-
-    redirect_to tag_path(@tag)
+    if @tag.update(tag_params)
+      render json: TagBlueprint.render(@tag)
+    else
+      render json: { errors: @tag.errors.full_messages }, status: :unprocessable_entity
+    end
   end
 
   def destroy

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -29,8 +29,7 @@ class TagsController < ApplicationController
 
   def destroy
     @tag.destroy
-
-    redirect_to tags_path
+    head :no_content
   end
 
   private

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TagsController < ApplicationController
   before_action :set_tag, only: %i[show update destroy]
 
@@ -42,5 +44,3 @@ class TagsController < ApplicationController
     @tag = Tag.find(params[:id])
   end
 end
-
-  

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,40 @@
+class TagsController < ApplicationController
+  before_action :set_tag, only: %i[show update destroy]
+
+  def index
+    @tags = Tag.all
+  end
+
+  def show
+  end
+
+  def create
+    tag = Tag.create(tag_params)
+
+    redirect_to tags_path
+  end
+
+  def update
+    @tag.update(tag_params)
+
+    redirect_to tag_path(@tag)
+  end
+
+  def destroy
+    @tag.destroy
+
+    redirect_to tags_path
+  end
+
+  private
+
+  def tag_params
+    params.require(:tag).permit(:name)
+  end
+
+  def set_tag
+    @tag = Tag.find(params[:id])
+  end
+end
+
+  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   resource :datetime, only: [:show]
+  resources :tags, only: [:index, :show, :create, :update, :destroy]
 end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tag do
+    sequence(:name) { |n| "Tag#{n}" }
+  end
+end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Tags", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -1,7 +1,109 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe "Tags", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "GET /tags" do
+    let!(:tags) { create_list(:tag, 10) }
+
+    it "returns a successful response" do
+      get '/tags'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns all tags" do
+      get '/tags'
+      expect(JSON.parse(response.body).length).to eq(10)
+    end
+  end
+
+  describe "GET /tags/:id" do
+    let(:tag) { create(:tag) }
+    let(:id) { tag.id }
+
+    context "when the tag exists" do
+      it "returns a successful response" do
+        get "/tags/#{id}"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns the tag" do
+        get "/tags/#{id}"
+        expect(JSON.parse(response.body)["id"]).to eq(id)
+      end
+    end
+
+    context "when the tag does not exist" do
+      it "returns status 404" do
+        get "/tags/999999"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe "POST /tags" do
+    context "with valid parameters" do
+      let(:valid_attributes) { { tag: { name: "NewTag" } } }
+
+      it "creates a new tag" do
+        post "/tags", params: valid_attributes
+        expect(response).to have_http_status(:created)
+      end
+
+      it "sets the correct name" do
+        post "/tags", params: valid_attributes
+        expect(JSON.parse(response.body)["name"]).to eq("NewTag")
+      end
+    end
+
+    context "with invalid parameters" do
+      it "returns unprocessable_entity" do
+        post "/tags", params: { tag: { name: "" } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "with missing parameters" do
+      it "returns bad_request" do
+        post "/tags", params: {}
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+
+  describe "PATCH /tags/:id" do
+    let(:tag) { create(:tag) }
+    let(:id) { tag.id }
+
+    context "with valid parameters" do
+      it "updates the tag" do
+        patch "/tags/#{id}", params: { tag: { name: "Updated" } }
+        expect(JSON.parse(response.body)["name"]).to eq("Updated")
+      end
+    end
+
+    context "with invalid parameters" do
+      it "returns unprocessable_entity" do
+        patch "/tags/#{id}", params: { tag: { name: "" } }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "DELETE /tags/:id" do
+    let(:tag) { create(:tag) }
+    let!(:id) { tag.id }
+
+    it "deletes the tag" do
+      expect {
+        delete "/tags/#{id}"
+      }.to change(Tag, :count).by(-1)
+    end
+
+    it "returns the http status code" do
+      delete "/tags/#{id}"
+
+      expect(response).to have_http_status(:no_content)
+    end
   end
 end


### PR DESCRIPTION
## Description
This PR introduces the implementation of the TagsController with full CRUD functionality, JSON serialization using the blueprinter gem, and standardized error handling. It also includes RSpec test coverage for all controller actions using FactoryBot for test data generation.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
All tests are passing successfully using FactoryBot and Rspec. Current test coverage is 98%.

- [x] Specs
- [x] Local
- [ ] QA Requried
